### PR TITLE
Update pi_fm_adv.c

### DIFF
--- a/src/pi_fm_adv.c
+++ b/src/pi_fm_adv.c
@@ -631,7 +631,7 @@ int main(int argc, char **argv) {
 				break;
 
 			case 'ecc': //ecc
-				ecc = strtoi(optarg, NULL, 16);
+				ecc = (int) strtol(optarg, NULL, 16);
 				break;
 				
 			case 'rt': //rt


### PR DESCRIPTION
strtoi() does not compile on RasPi. Proposal is to use strtol instead.